### PR TITLE
do not throw errors for CTL systems when the number of large log trees != 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucdavis/frcs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Fuel Reduction Cost Simulator",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",

--- a/src/systems/frcsrun.ts
+++ b/src/systems/frcsrun.ts
@@ -61,13 +61,6 @@ function createErrorMessages(params: InputVarMod) {
   ) {
     message +=
       'elevation is required to be a valid number for the system you have selected\n';
-  } else if (
-    (params.System === SystemTypes.groundBasedCtl ||
-      params.System === SystemTypes.cableCtl ||
-      params.System === SystemTypes.helicopterCtl) &&
-    params.RemovalsLLT !== 0
-  ) {
-    message += 'large log trees cannot be harvested in CTL systems\n';
   }
 
   // check that the values of some params do not exceed the limits


### PR DESCRIPTION
The existence of large log trees will not affect the results