### PR TITLE
Version 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucdavis/frcs",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucdavis/frcs",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Fuel Reduction Cost Simulator",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export const runFrcs = (params: FrcsInputs) => {
   return calculateHarvestCosts(params);
 };
 
-export const getMoveInCosts = (params: MoveInInputs) => {
+export const getMoveInOutputs = (params: MoveInInputs) => {
   return calculateMoveIn(params);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { FrcsInputs, MoveInInputs } from './model';
 
 import { calculateMoveIn } from './movein';
-import { calculateHarvestCosts } from './runfrcs';
+import { calculateFrcsOutputs } from './runfrcs';
 
-export const runFrcs = (params: FrcsInputs) => {
-  return calculateHarvestCosts(params);
+export const getFrcsOutputs = (params: FrcsInputs) => {
+  return calculateFrcsOutputs(params);
 };
 
 export const getMoveInOutputs = (params: MoveInInputs) => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -103,7 +103,7 @@ export interface MoveInInputs {
 
 export interface MoveInOutputs {
   totalCost: number;
-  biomassCost: number;
+  residualCost: number;
 }
 
 export class MoveInInputsDefault implements MoveInInputs {

--- a/src/model.ts
+++ b/src/model.ts
@@ -214,7 +214,7 @@ export interface FrcsOutputs {
     jetFuelPerAcre: number;
     jetFuelPerBoleCCF: number;
   };
-  biomass: {
+  residual: {
     yieldPerAcre: number;
     costPerAcre: number;
     costPerBoleCCF: number;

--- a/src/model.ts
+++ b/src/model.ts
@@ -99,11 +99,15 @@ export interface MoveInInputs {
   wageOther: number;
   laborBenefits: number;
   ppiCurrent: number;
+  volPerAcreCT: number;
+  includeCostsCollectChipResidues: boolean;
 }
 
 export interface MoveInOutputs {
   totalCost: number;
   residualCost: number;
+  totalDiesel: number;
+  residualDiesel: number;
 }
 
 export class MoveInInputsDefault implements MoveInInputs {
@@ -115,6 +119,8 @@ export class MoveInInputsDefault implements MoveInInputs {
   wageOther = 22.07; // CA AllOthersWage May 2020
   laborBenefits = 35; // Assume a nationwide average of 35% for benefits and other payroll costs
   ppiCurrent = 284.7; // Oct 2021
+  volPerAcreCT = 1000;
+  includeCostsCollectChipResidues = true;
   constructor() {}
 }
 

--- a/src/movein.ts
+++ b/src/movein.ts
@@ -125,7 +125,7 @@ export function calculateMoveIn(input: MoveInInputs) {
 
   const moveInOutputs: MoveInOutputs = {
     totalCost: 0,
-    biomassCost: 0,
+    residualCost: 0,
   };
   switch (input.system) {
     case SystemTypes.groundBasedMechWt:
@@ -182,7 +182,7 @@ export function calculateMoveIn(input: MoveInInputs) {
       // Total
       const totalBundleResidues =
         totalFixedBundleResidues + totalVariableBundleResidues * input.moveInDistance;
-      moveInOutputs.biomassCost = totalBundleResidues;
+      moveInOutputs.residualCost = totalBundleResidues;
       moveInOutputs.totalCost += totalBundleResidues;
       break;
     case SystemTypes.cableManualWtLog:
@@ -252,7 +252,7 @@ export function calculateMoveIn(input: MoveInInputs) {
   }
 
   if (input.isBiomassSalvage) {
-    moveInOutputs.biomassCost = moveInOutputs.totalCost;
+    moveInOutputs.residualCost = moveInOutputs.totalCost;
   }
 
   return moveInOutputs;

--- a/src/movein.ts
+++ b/src/movein.ts
@@ -14,6 +14,7 @@ export function calculateMoveIn(input: MoveInInputs) {
   const TravLoadedHrs = input.moveInDistance / SpeedLoaded;
   const BackhaulHrs = input.moveInDistance / SpeedBack;
   const LowboyCost = TruckMoveInCosts + TruckDriverMoveInCosts;
+  const MPG = 6;
   // System Costs
   const machineCost: MachineCosts = calculateMachineCosts(
     input.dieselFuelPrice,
@@ -126,10 +127,13 @@ export function calculateMoveIn(input: MoveInInputs) {
   const moveInOutputs: MoveInOutputs = {
     totalCost: 0,
     residualCost: 0,
+    totalDiesel: 0,
+    residualDiesel: 0,
   };
   switch (input.system) {
     case SystemTypes.groundBasedMechWt:
-      const LowboyLoadsMechWT = 4 + 1;
+      const LowboyLoadsMechWT =
+        4 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedMechWT =
         fellerbuncherFixed + skidderFixed + processorFixed + loaderFixed + chipperFixed;
       const BackhaulVariableMechWT = BackhaulVariablefunc(LowboyLoadsMechWT);
@@ -141,9 +145,11 @@ export function calculateMoveIn(input: MoveInInputs) {
         chipperVariable +
         BackhaulVariableMechWT;
       moveInOutputs.totalCost = totalFixedMechWT + totalVariableMechWT * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsMechWT * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.groundBasedManualWt:
-      const LowboyLoadsManualWT = 3 + 1;
+      const LowboyLoadsManualWT =
+        3 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedManualWT = skidderFixed + processorFixed + loaderFixed + chipperFixed;
       const BackhaulVariableManualWT = BackhaulVariablefunc(LowboyLoadsManualWT);
       const totalVariableManualWT =
@@ -153,17 +159,21 @@ export function calculateMoveIn(input: MoveInInputs) {
         chipperVariable +
         BackhaulVariableManualWT;
       moveInOutputs.totalCost = totalFixedManualWT + totalVariableManualWT * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsManualWT * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.groundBasedManualLog:
-      const LowboyLoadsManualLog = 2 + 1;
+      const LowboyLoadsManualLog =
+        2 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedManualLog = skidderFixed + loaderFixed + chipperFixed;
       const BackhaulVariableManualLog = BackhaulVariablefunc(LowboyLoadsManualLog);
       const totalVariableManualLog =
         skidderVariable + loaderVariable + chipperVariable + BackhaulVariableManualLog;
       moveInOutputs.totalCost = totalFixedManualLog + totalVariableManualLog * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsManualLog * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.groundBasedCtl:
-      const LowboyLoadsGroundCTL = 3 + 1;
+      const LowboyLoadsGroundCTL =
+        3 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedGroundCTL = harvesterFixed + forwarderFixed + loaderFixed + chipperFixed;
       const BackhaulVariableGroundCTL = BackhaulVariablefunc(LowboyLoadsGroundCTL);
       const totalVariableGroundCTL =
@@ -184,18 +194,32 @@ export function calculateMoveIn(input: MoveInInputs) {
         totalFixedBundleResidues + totalVariableBundleResidues * input.moveInDistance;
       moveInOutputs.residualCost = totalBundleResidues;
       moveInOutputs.totalCost += totalBundleResidues;
+      moveInOutputs.totalDiesel =
+        ((LowboyLoadsGroundCTL +
+          (input.includeCostsCollectChipResidues ? LowboyLoadsBundleResidues : 0)) *
+          2 *
+          input.moveInDistance) /
+        MPG;
+      moveInOutputs.residualDiesel =
+        ((input.includeCostsCollectChipResidues ? LowboyLoadsBundleResidues : 0) *
+          2 *
+          input.moveInDistance) /
+        MPG;
       break;
     case SystemTypes.cableManualWtLog:
-      const LowboyLoadsCableManualWTlog = 3 + 1;
+      const LowboyLoadsCableManualWTlog =
+        3 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedCableManualWTlog = yarderFixed + loaderFixed + chipperFixed;
       const BackhaulVariableCableManualWTlog = BackhaulVariablefunc(LowboyLoadsCableManualWTlog);
       const totalVariableCableManualWTlog =
         yarderVariable + loaderVariable + chipperVariable + BackhaulVariableCableManualWTlog;
       moveInOutputs.totalCost =
         totalFixedCableManualWTlog + totalVariableCableManualWTlog * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsCableManualWTlog * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.cableManualWt:
-      const LowboyLoadsCableManualWT = 4 + 1;
+      const LowboyLoadsCableManualWT =
+        4 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedCableManualWT = yarderFixed + processorFixed + loaderFixed + chipperFixed;
       const BackhaulVariableCableManualWT = BackhaulVariablefunc(LowboyLoadsCableManualWT);
       const totalVariableCableManualWT =
@@ -206,18 +230,22 @@ export function calculateMoveIn(input: MoveInInputs) {
         BackhaulVariableCableManualWT;
       moveInOutputs.totalCost =
         totalFixedCableManualWT + totalVariableCableManualWT * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsCableManualWT * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.cableManualLog:
-      const LowboyLoadsCableManualLog = 2 + 1;
+      const LowboyLoadsCableManualLog =
+        2 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedCableManualLog = yarderFixed + loaderFixed + chipperFixed;
       const BackhaulVariableCableManualLog = BackhaulVariablefunc(LowboyLoadsCableManualLog);
       const totalVariableCableManualLog =
         yarderVariable + loaderVariable + chipperVariable + BackhaulVariableCableManualLog;
       moveInOutputs.totalCost =
         totalFixedCableManualLog + totalVariableCableManualLog * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsCableManualLog * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.cableCtl:
-      const LowboyLoadsCableCTL = 3 + 1;
+      const LowboyLoadsCableCTL =
+        3 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedCableCTL = harvesterFixed + yarderFixed + loaderFixed + chipperFixed;
       const BackhaulVariableCableCTL = BackhaulVariablefunc(LowboyLoadsCableCTL);
       const totalVariableCableCTL =
@@ -227,18 +255,22 @@ export function calculateMoveIn(input: MoveInInputs) {
         chipperVariable +
         BackhaulVariableCableCTL;
       moveInOutputs.totalCost = totalFixedCableCTL + totalVariableCableCTL * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsCableCTL * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.helicopterManualLog:
-      const LowboyLoadsHManualLog = 2 + 1;
+      const LowboyLoadsHManualLog =
+        2 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedHManualLog = helicopterFixed + 2 * loaderFixed + chipperFixed;
       const BackhaulVariableHManualLog = BackhaulVariablefunc(LowboyLoadsHManualLog);
       const totalVariableHManualLog =
         helicopterVariable + 2 * loaderVariable + chipperVariable + BackhaulVariableHManualLog;
       moveInOutputs.totalCost =
         totalFixedHManualLog + totalVariableHManualLog * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsHManualLog * 2 * input.moveInDistance) / MPG;
       break;
     case SystemTypes.helicopterCtl:
-      const LowboyLoadsHeliCTL = 3 + 1;
+      const LowboyLoadsHeliCTL =
+        3 + (input.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
       const totalFixedHeliCTL = harvesterFixed + helicopterFixed + 2 * loaderFixed + chipperFixed;
       const BackhaulVariableHeliCTL = BackhaulVariablefunc(LowboyLoadsHeliCTL);
       const totalVariableHeliCTL =
@@ -248,11 +280,13 @@ export function calculateMoveIn(input: MoveInInputs) {
         chipperVariable +
         BackhaulVariableHeliCTL;
       moveInOutputs.totalCost = totalFixedHeliCTL + totalVariableHeliCTL * input.moveInDistance;
+      moveInOutputs.totalDiesel = (LowboyLoadsHeliCTL * 2 * input.moveInDistance) / MPG;
       break;
   }
 
   if (input.isBiomassSalvage) {
     moveInOutputs.residualCost = moveInOutputs.totalCost;
+    moveInOutputs.residualDiesel = moveInOutputs.totalDiesel;
   }
 
   return moveInOutputs;

--- a/src/runfrcs.ts
+++ b/src/runfrcs.ts
@@ -19,7 +19,7 @@ import { helicopterCTL } from './systems/helicopter-ctl';
 import { helicopterManualLog } from './systems/helicopter-manual-log';
 import { InLimits } from './systems/methods/inlimits';
 
-export function calculateHarvestCosts(input: FrcsInputs) {
+export function calculateFrcsOutputs(input: FrcsInputs) {
   const message = createErrorMessages(input);
   if (message) {
     throw new Error(message);

--- a/src/runfrcs.ts
+++ b/src/runfrcs.ts
@@ -175,7 +175,7 @@ function calculate(input: FrcsInputs) {
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import swaggerUi from 'swagger-ui-express';
 
 import { FrcsInputs, MoveInInputs } from './model';
 import { calculateMoveIn } from './movein';
-import { calculateHarvestCosts } from './runfrcs';
+import { calculateFrcsOutputs } from './runfrcs';
 
 // tslint:disable-next-line: no-var-requires
 const swaggerDocument = require('../swagger.json');
@@ -19,7 +19,7 @@ const port = process.env.PORT || 3000;
 app.post('/runfrcs', async (req, res) => {
   const params: FrcsInputs = req.body;
   try {
-    const result = await calculateHarvestCosts(params);
+    const result = await calculateFrcsOutputs(params);
     res.status(200).json(result);
   } catch (e) {
     res.status(400).send(e.message);

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,8 +15,8 @@ app.use(bodyParser.json());
 
 const port = process.env.PORT || 3000;
 
-// api endpoint for running frcs
-app.post('/runfrcs', async (req, res) => {
+// api endpoint for getting frcs outputs
+app.post('/frcs', async (req, res) => {
   const params: FrcsInputs = req.body;
   try {
     const result = await calculateFrcsOutputs(params);
@@ -27,7 +27,7 @@ app.post('/runfrcs', async (req, res) => {
   }
 });
 
-// api endpoint for calculating move-in costs
+// api endpoint for getting move-in outputs
 app.post('/movein', async (req, res) => {
   const params: MoveInInputs = req.body;
   try {

--- a/src/systems/cable-ctl.ts
+++ b/src/systems/cable-ctl.ts
@@ -107,7 +107,7 @@ export function cableCTL(
   const LowboyLoads = 4;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
 
   // III. Summaries
@@ -160,7 +160,8 @@ export function cableCTL(
   frcsOutputs.residual.costPerAcre =
     Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein + Movein4Residues;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;

--- a/src/systems/cable-ctl.ts
+++ b/src/systems/cable-ctl.ts
@@ -124,7 +124,7 @@ export function cableCTL(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -155,18 +155,18 @@ export function cableCTL(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre =
+  frcsOutputs.residual.costPerAcre =
     Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein + Movein4Residues;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/cable-manual-log.ts
+++ b/src/systems/cable-manual-log.ts
@@ -119,7 +119,7 @@ export function cableManualLog(
   const LowboyLoads = 3;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const GasolineStump2Truck4PrimaryProductWithoutMovein = ManualFellLimbBuckAllTrees2;
 
@@ -170,7 +170,8 @@ export function cableManualLog(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;

--- a/src/systems/cable-manual-log.ts
+++ b/src/systems/cable-manual-log.ts
@@ -137,7 +137,7 @@ export function cableManualLog(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -166,20 +166,20 @@ export function cableManualLog(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre =
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre =
     ManualFellLimbBuckAllTrees2 * (intermediate.boleWeightCT / intermediate.boleWeight);
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/cable-manual-log.ts
+++ b/src/systems/cable-manual-log.ts
@@ -54,7 +54,7 @@ export function cableManualLog(
   );
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalYardPCUB = CYPCUresults.GalYardPCUB;
   const GalYardCCUB = CYCCUresults.GalYardCCUB;
   const GalLoad = LoadingResults.GalLoad;

--- a/src/systems/cable-manual-wt-log.ts
+++ b/src/systems/cable-manual-wt-log.ts
@@ -63,7 +63,7 @@ export function cableManualWTLog(
   );
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalYardPCUB = CYPCUresults.GalYardPCUB;
   const GalYardCCUB = CYCCUresults.GalYardCCUB;
   const GalLoad = LoadingResults.GalLoad;

--- a/src/systems/cable-manual-wt-log.ts
+++ b/src/systems/cable-manual-wt-log.ts
@@ -139,7 +139,7 @@ export function cableManualWTLog(
   const LowboyLoads = 4;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
 
   // III. Summaries
@@ -193,7 +193,8 @@ export function cableManualWTLog(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;

--- a/src/systems/cable-manual-wt-log.ts
+++ b/src/systems/cable-manual-wt-log.ts
@@ -156,7 +156,7 @@ export function cableManualWTLog(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -189,19 +189,19 @@ export function cableManualWTLog(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/cable-manual-wt.ts
+++ b/src/systems/cable-manual-wt.ts
@@ -60,7 +60,7 @@ export function cableManualWT(
   );
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalYardPCUB = CYPCUresults.GalYardPCUB;
   const GalYardCCUB = CYCCUresults.GalYardCCUB;
   const GalProcess = ProcessingResults.GalProcess;

--- a/src/systems/cable-manual-wt.ts
+++ b/src/systems/cable-manual-wt.ts
@@ -144,7 +144,7 @@ export function cableManualWT(
   const LowboyLoads = 5;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const ChipLooseResiduesFromLogTreesLess80cf2 = input.includeCostsCollectChipResidues
     ? GalChipLooseRes * ResidueRecoveredOptional
@@ -204,7 +204,8 @@ export function cableManualWT(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2;

--- a/src/systems/cable-manual-wt.ts
+++ b/src/systems/cable-manual-wt.ts
@@ -165,7 +165,7 @@ export function cableManualWT(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -200,20 +200,20 @@ export function cableManualWT(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = OntoTruck4ResiduesWoMovein + Stump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre =
+  frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/ground-ctl.ts
+++ b/src/systems/ground-ctl.ts
@@ -157,9 +157,9 @@ export function groundCTL(
   const OntoTruck4ResiduesWoMovein2 =
     BundleCTLResidues2 + ForwardCTLResidues2 + ChipBundledResiduesFromTreesLess80cf2;
   const Movein4Residues2 =
-    input.includeMoveInCosts && input.includeCostsCollectChipResidues
+    input.includeMoveInCosts || input.includeCostsCollectChipResidues
       ? (2 * input.moveInDistance) / mpg / input.area
-      : 0;
+      : 0; // two equipment: a bundler and a forwarder
 
   // III. Summaries
   const frcsOutputs: FrcsOutputs = {
@@ -213,7 +213,8 @@ export function groundCTL(
   frcsOutputs.residual.costPerAcre =
     Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein + Movein4Residues;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2 + Movein4Residues2;

--- a/src/systems/ground-ctl.ts
+++ b/src/systems/ground-ctl.ts
@@ -141,6 +141,7 @@ export function groundCTL(
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
     ? ((LowboyLoads + (input.includeCostsCollectChipResidues ? LowboyLoadsResidues : 0)) *
+        2 *
         input.moveInDistance) /
       mpg /
       input.area
@@ -157,8 +158,8 @@ export function groundCTL(
   const OntoTruck4ResiduesWoMovein2 =
     BundleCTLResidues2 + ForwardCTLResidues2 + ChipBundledResiduesFromTreesLess80cf2;
   const Movein4Residues2 =
-    input.includeMoveInCosts || input.includeCostsCollectChipResidues
-      ? (2 * input.moveInDistance) / mpg / input.area
+    input.includeMoveInCosts && input.includeCostsCollectChipResidues
+      ? (LowboyLoadsResidues * 2 * input.moveInDistance) / mpg / input.area
       : 0; // two equipment: a bundler and a forwarder
 
   // III. Summaries

--- a/src/systems/ground-ctl.ts
+++ b/src/systems/ground-ctl.ts
@@ -175,7 +175,7 @@ export function groundCTL(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -208,19 +208,19 @@ export function groundCTL(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre =
+  frcsOutputs.residual.costPerAcre =
     Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein + Movein4Residues;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre =
+  frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2 + Movein4Residues2;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/ground-manual-log.ts
+++ b/src/systems/ground-manual-log.ts
@@ -54,7 +54,7 @@ export function groundManualLog(
   const FellAllTreesResults = FellAllTrees(input, intermediate, machineCost);
   const CostManFLB = FellAllTreesResults.CostManFLB;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalSkidUB = SkiddingResults.GalSkidUB;
   const GalLoad = LoadingResults.GalLoad;
   const GalChipWT = ChippingResults.GalChipWT;

--- a/src/systems/ground-manual-log.ts
+++ b/src/systems/ground-manual-log.ts
@@ -99,7 +99,7 @@ export function groundManualLog(
   const LowboyLoads = 3;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const GasolineStump2Truck4PrimaryProductWithoutMovein = ManualFellLimbBuckAllTrees2;
 
@@ -150,7 +150,8 @@ export function groundManualLog(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;

--- a/src/systems/ground-manual-log.ts
+++ b/src/systems/ground-manual-log.ts
@@ -117,7 +117,7 @@ export function groundManualLog(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -146,20 +146,20 @@ export function groundManualLog(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre =
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre =
     ManualFellLimbBuckAllTrees2 * (intermediate.boleWeightCT / intermediate.boleWeight);
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/ground-manual-wt.ts
+++ b/src/systems/ground-manual-wt.ts
@@ -60,7 +60,7 @@ export function groundManualWT(
   );
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalSkidUB = SkiddingResults.GalSkidUB;
   const GalProcess = ProcessingResults.GalProcess;
   const GalLoad = LoadingResults.GalLoad;

--- a/src/systems/ground-manual-wt.ts
+++ b/src/systems/ground-manual-wt.ts
@@ -134,7 +134,7 @@ export function groundManualWT(
   const LowboyLoads = 4;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const ChipLooseResiduesFromLogTreesLess80cf2 = input.includeCostsCollectChipResidues
     ? GalChipLooseRes * ResidueRecoveredOptional
@@ -194,7 +194,8 @@ export function groundManualWT(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2;

--- a/src/systems/ground-manual-wt.ts
+++ b/src/systems/ground-manual-wt.ts
@@ -155,7 +155,7 @@ export function groundManualWT(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -190,20 +190,20 @@ export function groundManualWT(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre =
+  frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/ground-mech-wt.ts
+++ b/src/systems/ground-mech-wt.ts
@@ -70,7 +70,7 @@ export function groundMechWT(
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
   const GalFellBunch = FellBunchResults.GalFellBunch;
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalSkidBun = SkiddingResults.GalSkidBun;
   const GalProcess = ProcessingResults.GalProcess;
   const GalLoad = LoadingResults.GalLoad;

--- a/src/systems/ground-mech-wt.ts
+++ b/src/systems/ground-mech-wt.ts
@@ -142,7 +142,7 @@ export function groundMechWT(
   const LowboyLoads = 5;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const ChipLooseResiduesFromLogTreesLess80cf2 = input.includeCostsCollectChipResidues
     ? GalChipLooseRes * ResidueRecoveredOptional

--- a/src/systems/ground-mech-wt.ts
+++ b/src/systems/ground-mech-wt.ts
@@ -163,7 +163,7 @@ export function groundMechWT(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -198,18 +198,18 @@ export function groundMechWT(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre =
+  frcsOutputs.residual.dieselPerAcre =
     DieselStump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein2 + ChipWholeTrees2;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/helicopter-ctl.ts
+++ b/src/systems/helicopter-ctl.ts
@@ -104,7 +104,7 @@ export function helicopterCTL(
   const LowboyLoads = 4;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const JetFuelStump2Truck4PrimaryProductWithoutMovein = HeliYardCTLtreesLess80cf2;
   const JetFuelStump2Truck4ResiduesWithoutMovein =

--- a/src/systems/helicopter-ctl.ts
+++ b/src/systems/helicopter-ctl.ts
@@ -124,7 +124,7 @@ export function helicopterCTL(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -157,20 +157,20 @@ export function helicopterCTL(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre =
+  frcsOutputs.residual.costPerAcre =
     Stump2Truck4ResiduesWithoutMovein + OntoTruck4ResiduesWoMovein + Movein4Residues;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.jetFuelPerAcre = JetFuelStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.jetFuelPerBoleCCF = frcsOutputs.biomass.jetFuelPerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.jetFuelPerAcre = JetFuelStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.jetFuelPerBoleCCF = frcsOutputs.residual.jetFuelPerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/helicopter-manual-log.ts
+++ b/src/systems/helicopter-manual-log.ts
@@ -102,7 +102,7 @@ export function helicopterManualLog(
   const LowboyLoads = 3;
   const mpg = 6;
   const Movein4PrimaryProduct2 = input.includeMoveInCosts
-    ? (LowboyLoads * input.moveInDistance) / mpg / input.area
+    ? (LowboyLoads * 2 * input.moveInDistance) / mpg / input.area
     : 0;
   const GasolineStump2Truck4PrimaryProductWithoutMovein = ManualFellLimbBuckAllTrees2;
   const GasolineStump2Truck4ResiduesWithoutMovein =
@@ -164,7 +164,8 @@ export function helicopterManualLog(
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
   frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
-  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerGT =
+    frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
   frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
   frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;

--- a/src/systems/helicopter-manual-log.ts
+++ b/src/systems/helicopter-manual-log.ts
@@ -125,7 +125,7 @@ export function helicopterManualLog(
       jetFuelPerAcre: 0,
       jetFuelPerBoleCCF: 0,
     },
-    biomass: {
+    residual: {
       yieldPerAcre: 0,
       costPerAcre: 0,
       costPerBoleCCF: 0,
@@ -160,21 +160,21 @@ export function helicopterManualLog(
 
   // System Summaries - Residue
   // Cost
-  frcsOutputs.biomass.yieldPerAcre =
+  frcsOutputs.residual.yieldPerAcre =
     ResidueRecoveredOptional + intermediate.boleWeightCT + ResidueRecoveredPrimary;
-  frcsOutputs.biomass.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.costPerBoleCCF = frcsOutputs.biomass.costPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.costPerGT = frcsOutputs.biomass.costPerAcre / frcsOutputs.total.yieldPerAcre;
+  frcsOutputs.residual.costPerAcre = Stump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.costPerBoleCCF = frcsOutputs.residual.costPerAcre / BoleVolCCF;
+  frcsOutputs.residual.costPerGT = frcsOutputs.residual.costPerAcre / frcsOutputs.total.yieldPerAcre;
   // Fuel
-  frcsOutputs.biomass.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.dieselPerBoleCCF = frcsOutputs.biomass.dieselPerAcre / BoleVolCCF;
-  frcsOutputs.biomass.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.gasolinePerBoleCCF = frcsOutputs.biomass.gasolinePerAcre / BoleVolCCF;
-  frcsOutputs.biomass.jetFuelPerAcre = JetFuelStump2Truck4ResiduesWithoutMovein;
-  frcsOutputs.biomass.jetFuelPerBoleCCF = frcsOutputs.biomass.jetFuelPerAcre / BoleVolCCF;
+  frcsOutputs.residual.dieselPerAcre = DieselStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.dieselPerBoleCCF = frcsOutputs.residual.dieselPerAcre / BoleVolCCF;
+  frcsOutputs.residual.gasolinePerAcre = GasolineStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.gasolinePerBoleCCF = frcsOutputs.residual.gasolinePerAcre / BoleVolCCF;
+  frcsOutputs.residual.jetFuelPerAcre = JetFuelStump2Truck4ResiduesWithoutMovein;
+  frcsOutputs.residual.jetFuelPerBoleCCF = frcsOutputs.residual.jetFuelPerAcre / BoleVolCCF;
 
   if (input.isBiomassSalvage) {
-    frcsOutputs.biomass = frcsOutputs.total;
+    frcsOutputs.residual = frcsOutputs.total;
   }
 
   return frcsOutputs;

--- a/src/systems/helicopter-manual-log.ts
+++ b/src/systems/helicopter-manual-log.ts
@@ -50,7 +50,7 @@ export function helicopterManualLog(
   );
   const CostChipLooseRes = ChippingResults.CostChipLooseRes;
 
-  const GalChainsaw = 0.0104 * 2.83168 * 0.264172; // 0.0104 L/m3 => gal/CCF
+  const GalChainsaw = 0.077797403;
   const GalHeliYardML = HelicopterYardingResults.GalHeliYardML;
   const LoadingResults = Loading(assumption, input, intermediate, machineCost);
   const GalLoad = LoadingResults.GalLoad;

--- a/src/systems/methods/moveincost.ts
+++ b/src/systems/methods/moveincost.ts
@@ -124,7 +124,8 @@ function MoveInCosts(
   const helicopterVariable = helicopterVariablefunc();
 
   // Mech WT
-  const LowboyLoadsMechWT = 4 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsMechWT =
+    4 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedMechWT =
     fellerbuncherFixed + skidderFixed + processorFixed + loaderFixed + chipperFixed;
   const BackhaulVariableMechWT = BackhaulVariablefunc(LowboyLoadsMechWT);
@@ -141,7 +142,8 @@ function MoveInCosts(
     (totalMechWT * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Manual WT
-  const LowboyLoadsManualWT = 3 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsManualWT =
+    3 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedManualWT = skidderFixed + processorFixed + loaderFixed + chipperFixed;
   const BackhaulVariableManualWT = BackhaulVariablefunc(LowboyLoadsManualWT);
   const totalVariableManualWT =
@@ -156,7 +158,8 @@ function MoveInCosts(
     (totalManualWT * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Manual Log
-  const LowboyLoadsManualLog = 2 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsManualLog =
+    2 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedManualLog = skidderFixed + loaderFixed + chipperFixed;
   const BackhaulVariableManualLog = BackhaulVariablefunc(LowboyLoadsManualLog);
   const totalVariableManualLog =
@@ -167,7 +170,8 @@ function MoveInCosts(
     (totalManualLog * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Ground CTL
-  const LowboyLoadsGroundCTL = 3 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsGroundCTL =
+    3 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedGroundCTL = harvesterFixed + forwarderFixed + loaderFixed + chipperFixed;
   const BackhaulVariableGroundCTL = BackhaulVariablefunc(LowboyLoadsGroundCTL);
   const totalVariableGroundCTL =
@@ -182,7 +186,8 @@ function MoveInCosts(
     (totalGroundCTL * 100) / (input.area * intermediate.volumeST * intermediate.treesPerAcreST);
 
   // Cable Manual WT/Log
-  const LowboyLoadsCableManualWTlog = 3 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsCableManualWTlog =
+    3 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedCableManualWTlog = yarderFixed + loaderFixed + chipperFixed;
   const BackhaulVariableCableManualWTlog = BackhaulVariablefunc(LowboyLoadsCableManualWTlog);
   const totalVariableCableManualWTlog =
@@ -194,7 +199,8 @@ function MoveInCosts(
     (totalCableManualWTlog * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Cable Manual WT
-  const LowboyLoadsCableManualWT = 4 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsCableManualWT =
+    4 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedCableManualWT = yarderFixed + processorFixed + loaderFixed + chipperFixed;
   const BackhaulVariableCableManualWT = BackhaulVariablefunc(LowboyLoadsCableManualWT);
   const totalVariableCableManualWT =
@@ -210,7 +216,8 @@ function MoveInCosts(
     (totalCableManualWT * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Cable Manual Log
-  const LowboyLoadsCableManualLog = 2 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsCableManualLog =
+    2 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedCableManualLog = yarderFixed + loaderFixed + chipperFixed;
   const BackhaulVariableCableManualLog = BackhaulVariablefunc(LowboyLoadsCableManualLog);
   const totalVariableCableManualLog =
@@ -222,7 +229,8 @@ function MoveInCosts(
     (totalCableManualLog * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Cable CTL
-  const LowboyLoadsCableCTL = 3 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsCableCTL =
+    3 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedCableCTL = harvesterFixed + yarderFixed + loaderFixed + chipperFixed;
   const BackhaulVariableCableCTL = BackhaulVariablefunc(LowboyLoadsCableCTL);
   const totalVariableCableCTL =
@@ -237,7 +245,8 @@ function MoveInCosts(
     (totalCableCTL * 100) / (input.area * intermediate.volumeST * intermediate.treesPerAcreST);
 
   // Helicopter Manual Log
-  const LowboyLoadsHManualLog = 2 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsHManualLog =
+    2 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedHManualLog = helicopterFixed + 2 * loaderFixed + chipperFixed;
   const BackhaulVariableHManualLog = BackhaulVariablefunc(LowboyLoadsHManualLog);
   const totalVariableHManualLog =
@@ -248,7 +257,8 @@ function MoveInCosts(
     (totalHManualLog * 100) / (input.area * intermediate.volume * intermediate.treesPerAcre);
 
   // Helicopter CTL
-  const LowboyLoadsHeliCTL = 3 + (intermediate.volPerAcreCT > 0 ? 1 : 0);
+  const LowboyLoadsHeliCTL =
+    3 + (intermediate.volPerAcreCT > 0 || input.includeCostsCollectChipResidues ? 1 : 0);
   const totalFixedHeliCTL = harvesterFixed + helicopterFixed + 2 * loaderFixed + chipperFixed;
   const BackhaulVariableHeliCTL = BackhaulVariablefunc(LowboyLoadsHeliCTL);
   const totalVariableHeliCTL =

--- a/swagger.json
+++ b/swagger.json
@@ -306,8 +306,8 @@
         "total": {
           "$ref": "#/definitions/Total"
         },
-        "biomass": {
-          "$ref": "#/definitions/Biomass"
+        "residual": {
+          "$ref": "#/definitions/Residual"
         }
       },
       "xml": {
@@ -379,10 +379,10 @@
         }
       },
       "xml": {
-        "name": "total"
+        "name": "Total"
       }
     },
-    "Biomass": {
+    "Residual": {
       "type": "object",
       "properties": {
         "yieldPerAcre": {
@@ -447,7 +447,7 @@
         }
       },
       "xml": {
-        "name": "biomass"
+        "name": "Residual"
       }
     }
   },

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "This is a service for running FRCS on a harvest unit in California, funded by California Energy Commission.",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "title": "Fuel Reduction Cost Simulator Web Service",
     "contact": {
       "email": "kkyli@ucdavis.edu"
@@ -15,15 +15,11 @@
   "paths": {
     "/frcs": {
       "post": {
-        "tags": [
-          "FRCS"
-        ],
+        "tags": ["FRCS"],
         "summary": "Get FRCS Outputs",
         "description": "| Limits | Ground-Based Mech WT | Ground-Based CTL | Ground-Based Manual WT | Ground-Based Manual Log | Cable Manual WT/Log | Cable Manual WT | Cable Manual Log | Cable CTL | Helicopter Manual Log | Helicopter CTL |\n|-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|\n| TreeVol Max CT, ft3 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 |\n| TreeVol Max SLT, ft3 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 |\n| TreeVol Max LLT, ft3 | 250 |  | 250 | 250 | 250 | 250 | 250 |  | 250 |  |\n| Max LLT/ac |  | 10 |  |  |  |  |  | 10 |  | 10 |\n| Max LLT as % of ALT |  | 10 |  |  |  |  |  | 10 |  | 10 |\n| Max slope, % | 40 | 40 | 40 | 40 | 100 | 100 | 100 | 40 | 100 | 40 |\n| Max Yarding Dist, ft |  |  |  |  | 1300 | 1300 | 1300 | 1300 | 10000 | 10000 |\n",
         "operationId": "getFrcsOutputs",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "body",
@@ -390,19 +386,19 @@
           "format": "float",
           "example": 50.518225,
           "description": "Yield of Residual Woody Biomass in Green Tons per Acre."
-        }, 
+        },
         "costPerAcre": {
           "type": "number",
           "format": "float",
           "example": 534.2228831,
           "description": "Cost of Harvesting Residual Woody Biomass in US dollars per Acre."
-        }, 
+        },
         "costPerBoleCCF": {
           "type": "number",
           "format": "float",
           "example": 10.68445766,
           "description": "Cost of Harvesting Residual Woody Biomass in US dollars per Hundred Cubic Feet."
-        }, 
+        },
         "costPerGT": {
           "type": "number",
           "format": "float",

--- a/swagger.json
+++ b/swagger.json
@@ -13,14 +13,14 @@
     }
   },
   "paths": {
-    "/runfrcs": {
+    "/frcs": {
       "post": {
         "tags": [
           "FRCS"
         ],
-        "summary": "Compute harvest costs",
+        "summary": "Get FRCS Outputs",
         "description": "| Limits | Ground-Based Mech WT | Ground-Based CTL | Ground-Based Manual WT | Ground-Based Manual Log | Cable Manual WT/Log | Cable Manual WT | Cable Manual Log | Cable CTL | Helicopter Manual Log | Helicopter CTL |\n|-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|\n| TreeVol Max CT, ft3 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 |\n| TreeVol Max SLT, ft3 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 | 80 |\n| TreeVol Max LLT, ft3 | 250 |  | 250 | 250 | 250 | 250 | 250 |  | 250 |  |\n| Max LLT/ac |  | 10 |  |  |  |  |  | 10 |  | 10 |\n| Max LLT as % of ALT |  | 10 |  |  |  |  |  | 10 |  | 10 |\n| Max slope, % | 40 | 40 | 40 | 40 | 100 | 100 | 100 | 40 | 100 | 40 |\n| Max Yarding Dist, ft |  |  |  |  | 1300 | 1300 | 1300 | 1300 | 10000 | 10000 |\n",
-        "operationId": "runFrcs",
+        "operationId": "getFrcsOutputs",
         "produces": [
           "application/json"
         ],


### PR DESCRIPTION
- Correct gasoline fuel consumption of using chainsaws
- Rename functions to `getFrcsOutputs` and `getMoveInOutputs`
- Add diesel fuel consumption to `MoveInOutputs` model
- Correct the calculations of diesel fuel consumption by doubling the total move-in distance
- Have `calculateMoveIn` function calculate and output diesel fuel consumption
- Rename api endpoint to from `runfrcs` to `frcs`
- Update swagger accordingly  
